### PR TITLE
Reorder sample assessment output

### DIFF
--- a/bin/pca-import
+++ b/bin/pca-import
@@ -106,8 +106,8 @@ def output_assessment_template():
     assessment["start_time"] = "2017-01-01"
     assessment["end_time"] = "2017-01-21"
     # Override default behavior to sort JSON key values
-    # Values should be displayed in the order they were built in. 
-    print(util.to_json(assessment,sort_keys=False))
+    # Values should be displayed in the order they were built in.
+    print(util.to_json(assessment, sort_keys=False))
     sys.exit(0)
 
 

--- a/bin/pca-import
+++ b/bin/pca-import
@@ -105,7 +105,8 @@ def output_assessment_template():
     assessment["team_lead"] = "Test Testerton"
     assessment["start_time"] = "2017-01-01"
     assessment["end_time"] = "2017-01-21"
-    print(util.to_json(assessment,sort_keys=False))
+    print(util.to_json(assessment,sort_keys=False)) # Override default behavior to sort JSON key values
+                                                    # Values should be displayed in the order they were built in. 
     sys.exit(0)
 
 

--- a/bin/pca-import
+++ b/bin/pca-import
@@ -105,7 +105,7 @@ def output_assessment_template():
     assessment["team_lead"] = "Test Testerton"
     assessment["start_time"] = "2017-01-01"
     assessment["end_time"] = "2017-01-21"
-    print(json.dumps(assessment, sort_keys=False, indent=4))
+    print(util.to_json(assessment,sort_keys=False))
     sys.exit(0)
 
 

--- a/bin/pca-import
+++ b/bin/pca-import
@@ -105,8 +105,9 @@ def output_assessment_template():
     assessment["team_lead"] = "Test Testerton"
     assessment["start_time"] = "2017-01-01"
     assessment["end_time"] = "2017-01-21"
-    print(util.to_json(assessment,sort_keys=False)) # Override default behavior to sort JSON key values
-                                                    # Values should be displayed in the order they were built in. 
+    # Override default behavior to sort JSON key values
+    # Values should be displayed in the order they were built in. 
+    print(util.to_json(assessment,sort_keys=False))
     sys.exit(0)
 
 

--- a/bin/pca-import
+++ b/bin/pca-import
@@ -105,7 +105,7 @@ def output_assessment_template():
     assessment["team_lead"] = "Test Testerton"
     assessment["start_time"] = "2017-01-01"
     assessment["end_time"] = "2017-01-21"
-    print(util.to_json(assessment))
+    print(json.dumps(assessment, indent=True))
     sys.exit(0)
 
 

--- a/bin/pca-import
+++ b/bin/pca-import
@@ -105,7 +105,7 @@ def output_assessment_template():
     assessment["team_lead"] = "Test Testerton"
     assessment["start_time"] = "2017-01-01"
     assessment["end_time"] = "2017-01-21"
-    print(json.dumps(assessment, indent=True))
+    print(json.dumps(assessment, sort_keys=False, indent=4))
     sys.exit(0)
 
 

--- a/pca/util/util.py
+++ b/pca/util/util.py
@@ -101,8 +101,8 @@ def pp(obj):
     print(to_json(obj))
 
 
-def to_json(obj):
-    return json.dumps(obj, sort_keys=True, indent=4, default=custom_json_handler)
+def to_json(obj, sort_keys=True):
+    return json.dumps(obj, sort_keys=sort_keys, indent=4, default=custom_json_handler)
 
 
 def isXML(filename):


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

The  pca-import --sample-assessment command shows the end_date preceding the start_date in the example shown. This should be swapped so as not to confuse the PCA operators. 

## 💭 Motivation and context ##

The PCA Team wants the start_date and end_date swapped in the output. The default behavior sorts the JSON by key value, but the team is confused when manually building the input file by having the end_date coming before the start_date in the output. A change was made to not sort the JSON and display it as is. 

Closes #10 
## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I reran `python3 pca-import --sample-assessment` and viewed the resulting JSON output to verify it displayed start_date before end_date. 


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
